### PR TITLE
Add DBeaver to tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [LINQPad](https://www.linqpad.net/) - LINQPad is not just for LINQ queries, but any C#/F#/VB expression, statement block or program.
 - [SchemaSpy](https://github.com/schemaspy/schemaspy) - we will do the best to simplify documentation process of your database
 - [MissionKontrol](https://github.com/Mission-Kontrol/MissionKontrol) - Self-hosted admin panel to manage one or more MySQL/PostGRES databases.
+- [DBeaver](https://dbeaver.io) - Free multi-platform database tool for developers, database administrators, analysts and all people who need to work with databases. Supports all popular databases.
 
 ## <a name="resources"></a>Resources
 


### PR DESCRIPTION
This pull request adds [DBeaver](https://dbeaver.io/) to the tools section.

DBeaver is a free multi-platform database tool for developers, database administrators, analysts and all people who need to work with databases. Supports all popular databases: MySQL, PostgreSQL, SQLite, Oracle, DB2, SQL Server, Sybase, MS Access, Teradata, Firebird, Apache Hive, Phoenix, Presto, etc.

It uses the [Apache 2.0 License](https://dbeaver.io/product/dbeaver_license.txt)